### PR TITLE
Add file engine/misc.txt to add a unique game prefix.

### DIFF
--- a/new_game_mod/engine/misc.txt
+++ b/new_game_mod/engine/misc.txt
@@ -1,0 +1,5 @@
+
+# The game prefix makes sure to have new save slots,
+# so it doesn't comflict with the default slots of
+# flare-game
+game_prefix=noname_mod_by_ryan_dansie


### PR DESCRIPTION
This setting makes sure there will be no conflicts of savefiles
between this mod and any other mod (such as alpha_demo), with respect
to items, levels, xp table, and so on.

Signed-off-by: Stefan Beller stefanbeller@googlemail.com
